### PR TITLE
Skip color_matches when not using colors already

### DIFF
--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -310,11 +310,13 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         matches = [self.color_for_obj(i, name, obj)
                    for i, name, obj
                    in izip(count(), names, values)]
-        # we add a space at the end to prevent the automatic completion of the
-        # common prefix, which is the ANSI ESCAPE sequence
-        if matches:
+        # We add a space at the end to prevent the automatic completion of the
+        # common prefix, which is the ANSI ESCAPE sequence.
+        # We typically come here with more than 1 match always, otherwise
+        # it would not use coloring (with common prefix).
+        if len(matches) > 1:
             return matches + [' ']
-        return []
+        return matches
 
     def color_for_obj(self, i, name, value):
         t = type(value)

--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -304,6 +304,9 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         return self.color_matches(names, values)
 
     def color_matches(self, names, values):
+        if not self.config.use_colors:
+            return names
+
         matches = [self.color_for_obj(i, name, obj)
                    for i, name, obj
                    in izip(count(), names, values)]
@@ -314,8 +317,6 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         return []
 
     def color_for_obj(self, i, name, value):
-        if not self.config.use_colors:
-            return name
         t = type(value)
         color = self.config.color_by_type.get(t, '00')
         # hack: prepend an (increasing) fake escape sequence,

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -6,6 +6,11 @@ class ConfigForTest(DefaultConfig):
     use_colors = False
 
 
+class ColorConfig(DefaultConfig):
+    use_colors = True
+    color_by_type = {type: '31'}
+
+
 def test_commonprefix():
     assert commonprefix(['isalpha', 'isdigit', 'foo']) == ''
     assert commonprefix(['isalpha', 'isdigit']) == 'is'
@@ -24,18 +29,23 @@ def test_complete_attribute():
 
 
 def test_complete_attribute_colored():
-    class ColorConfig(DefaultConfig):
-        use_colors = True
-        color_by_type = {type: '31'}
-
     compl = Completer({'a': 42}, ColorConfig)
     matches = compl.attr_matches('a.__')
+    assert len(matches) > 2
+    expected_part = Color.set('31', '__class__')
     for match in matches:
-        if Color.set('31', '__class__') in match:
+        if expected_part in match:
             break
     else:
         assert False
     assert ' ' in matches
+
+
+def test_complete_colored_single_match():
+    """No coloring, via commonprefix."""
+    compl = Completer({'foobar': 42}, ColorConfig)
+    matches = compl.global_matches('foob')
+    assert matches == ['foobar']
 
 
 def test_complete_global():

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -42,7 +42,7 @@ def test_complete_global():
     compl = Completer({'foobar': 1, 'foobazzz': 2}, ConfigForTest)
     assert compl.global_matches('foo') == ['fooba']
     matches = compl.global_matches('fooba')
-    assert set(matches) == set(['foobar', 'foobazzz', ' '])
+    assert set(matches) == set(['foobar', 'foobazzz'])
     assert compl.global_matches('foobaz') == ['foobazzz']
 
 
@@ -69,7 +69,7 @@ def test_autocomplete():
     # automatically insert the common prefix (which will the the ANSI escape
     # sequence if we use colors)
     matches = compl.attr_matches('A.a')
-    assert sorted(matches) == [' ', 'aaa', 'abc_1', 'abc_2', 'abc_3']
+    assert sorted(matches) == ['aaa', 'abc_1', 'abc_2', 'abc_3']
     #
     # IF there is an actual common prefix, we return just it, so that readline
     # will insert it into place
@@ -80,7 +80,7 @@ def test_autocomplete():
     # for this common prefix. Agai, we insert a spurious space to prevent the
     # automatic completion of ANSI sequences
     matches = compl.attr_matches('A.abc_')
-    assert sorted(matches) == [' ', 'abc_1', 'abc_2', 'abc_3']
+    assert sorted(matches) == ['abc_1', 'abc_2', 'abc_3']
 
 
 def test_complete_exception():
@@ -100,7 +100,7 @@ def test_unicode_in___dir__():
 
     compl = Completer({'a': Foo()}, ConfigForTest)
     matches = compl.attr_matches('a.')
-    assert matches == ['hello', 'world', ' ']
+    assert matches == ['hello', 'world']
     assert type(matches[0]) is str
 
 


### PR DESCRIPTION
This avoids adding the space used for common escape sequences in the
first place.