### PR TITLE
Use readline docstring to detect libedit

### DIFF
--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -345,13 +345,10 @@ def has_leopard_libedit(config):
     # Adapted from IPython's rlineimpl.py.
     if config.using_pyrepl or sys.platform != 'darwin':
         return False
-    from subprocess import Popen, PIPE
-    cmd = ["otool", "-L", config.readline.__file__]
-    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    stdout, stderr = p.communicate()
-    if p.returncode == 0 and 'libedit' in stdout.decode('utf-8'):
-        return True
-    return False
+
+    # Official Python docs state that 'libedit' is in the docstring for
+    # libedit readline.
+    return config.readline.__doc__ and 'libedit' in config.readline.__doc__
 
 
 def setup():


### PR DESCRIPTION
For posterity: fancycompleter's detection of libedit was based off of IPython's readline compat module. IPython seems to have changed [their detection algorithm](https://github.com/ipython/rlipython/blob/e218435e396a5798e001f732afa5b5e5fdc93ce0/rlipython/rlineimpl.py) to rely on the existence of `'libedit'` in the `readline` module's docstring.

This PR changes fancycompleter's libedit detection to match IPython's.

ref: [#4](https://github.com/pdbpp/fancycompleter/pull/4#issuecomment-496259254)