### PR TITLE
Add interactive test using pexpect

### DIFF
--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -351,11 +351,11 @@ def has_leopard_libedit(config):
     return config.readline.__doc__ and 'libedit' in config.readline.__doc__
 
 
-def setup():
+def setup(**kwargs):
     """
     Install fancycompleter as the default completer for readline.
     """
-    completer = Completer()
+    completer = Completer(**kwargs)
     readline = completer.config.readline
     if has_leopard_libedit(completer.config):
         readline.parse_and_bind("bind ^I rl_complete")
@@ -390,7 +390,7 @@ def setup_history(completer, persist_history):
     atexit.register(save_history)
 
 
-def interact(persist_history=None):
+def interact(persist_history=None, **kwargs):
     """
     Main entry point for fancycompleter: run an interactive Python session
     after installing fancycompleter.
@@ -411,7 +411,7 @@ def interact(persist_history=None):
     By default, pyrepl is preferred and automatically used if found.
     """
     import sys
-    completer = setup()
+    completer = setup(**kwargs)
     if persist_history:
         setup_history(completer, persist_history)
     if completer.config.using_pyrepl and '__pypy__' not in sys.builtin_module_names:

--- a/testing/fcomplete.py
+++ b/testing/fcomplete.py
@@ -1,0 +1,24 @@
+import cmd
+import sys
+
+from fancycompleter import interact, DefaultConfig
+
+
+class ConfigForTest(DefaultConfig):
+    use_colors = False
+
+
+class CompleterCmd(cmd.Cmd):
+    prompt = ''
+
+
+if __name__ == '__main__':
+    globals().update({
+        name: name
+        for name in sys.argv[1:]
+    })
+
+    interact(Config=ConfigForTest)
+
+    repl = CompleterCmd(completekey=None)
+    repl.cmdloop(intro='')

--- a/testing/test_interactive.py
+++ b/testing/test_interactive.py
@@ -1,0 +1,42 @@
+import os.path
+import time
+
+import pexpect
+
+
+TEST_DIR = os.path.dirname(__file__)
+FCOMPLETE_PATH = os.path.join(TEST_DIR, 'fcomplete.py')
+
+
+def test_global_matches():
+    prefix = 'complete_'
+    names = ['a', 'b', 'c']
+    full_names = [prefix + name for name in names]
+
+    args = [FCOMPLETE_PATH]
+    args.extend(full_names)
+
+    fcomplete = pexpect.spawn('python', args)
+
+    try:
+        fcomplete.send(prefix)
+        output = fcomplete.read_nonblocking(1000).decode('utf-8')
+        assert output == prefix
+
+        fcomplete.send('\t')
+        fcomplete.read_nonblocking(1000).decode('utf-8')
+
+        fcomplete.send('\t')
+        time.sleep(0.1)
+        output = fcomplete.read_nonblocking(1000).decode('utf-8')
+        lines = output.split('\r\n')
+
+        assert len(lines) == 3
+        assert lines[2].endswith(prefix)
+
+        assert all(full_name in lines[1] for full_name in full_names)
+        completed_names = lines[1].strip().split('  ')
+        assert set(completed_names) == set(full_names)
+
+    finally:
+        fcomplete.terminate(force=True)


### PR DESCRIPTION
I spent some time messing about to find a way to test fancycompleter's interactive features. This PR has an example utilizing [pexpect](https://github.com/pexpect/pexpect) to spawn a [cmd-module](https://docs.python.org/3/library/cmd.html)-based REPL backed by fancycompleter.

I tested it on Linux and OSX. It fails on Linux if `has_leopard_libedit` is forced to `return False`.

The pexpect dep was just for convenience, and could likely be replaced with direct usage of [`pty`](https://docs.python.org/3/library/pty.html).

Hope it helps!