### PR TITLE
Fix/improve ConfigurableClass.get_config

### DIFF
--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -195,15 +195,25 @@ class ConfigurableClass:
         # try to load config from the ~/filename file
         filename = '~/' + self.config_filename
         rcfile = os.path.expanduser(filename)
-        if os.path.exists(rcfile):
-            mydict = {}
-            try:
-                my_execfile(rcfile, mydict)
-                return mydict['Config']()
-            except Exception:
-                # python 2.5 compatibility, can't use 'except Exception as e'
-                e = sys.exc_info()[1]
-                print('** error when importing %s: %s **' % (filename, e))
+        if not os.path.exists(rcfile):
+            return self.DefaultConfig()
+
+        mydict = {}
+        try:
+            my_execfile(rcfile, mydict)
+        except Exception as exc:
+            print('** error when importing %s: %s **' % (filename, exc), file=sys.stderr)
+            return self.DefaultConfig()
+
+        try:
+            Config = mydict['Config']
+        except KeyError:
+            return self.DefaultConfig()
+
+        try:
+            return Config()
+        except Exception as exc:
+            print('** error when getting Config from %s: %s **' % (filename, exc), file=sys.stderr)
         return self.DefaultConfig()
 
 

--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -202,18 +202,20 @@ class ConfigurableClass:
         try:
             my_execfile(rcfile, mydict)
         except Exception as exc:
-            print('** error when importing %s: %s **' % (filename, exc), file=sys.stderr)
+            sys.stderr.write("** error when importing %s: %s **\n" % (filename, exc))
             return self.DefaultConfig()
 
         try:
-            Config = mydict['Config']
+            Config = mydict["Config"]
         except KeyError:
             return self.DefaultConfig()
 
         try:
             return Config()
         except Exception as exc:
-            print('** error when getting Config from %s: %s **' % (filename, exc), file=sys.stderr)
+            sys.stderr.write(
+                "** error when getting Config from %s: %s **\n" % (filename, exc)
+            )
         return self.DefaultConfig()
 
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture
+def tmphome(tmpdir, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmpdir))
+    monkeypatch.setenv("USERPROFILE", str(tmpdir))
+
+    with tmpdir.as_cwd():
+        yield tmpdir

--- a/testing/test_configurableclass.py
+++ b/testing/test_configurableclass.py
@@ -1,0 +1,43 @@
+from fancycompleter import ConfigurableClass
+
+
+def test_config(tmphome, capsys):
+    class DefaultCfg:
+        default = 42
+
+    class MyCfg(ConfigurableClass):
+        DefaultConfig = DefaultCfg
+        config_filename = ".mycfg"
+
+    cfg = MyCfg()
+
+    # Calls passed in Config.
+    assert cfg.get_config(Config=lambda: "42") == "42"
+
+    # Uses DefaultConfig instance.
+    assert isinstance(cfg.get_config(None), DefaultCfg)
+
+    cfgfile = tmphome.join(MyCfg.config_filename)
+
+    # Handles empty config file (missing "Config").
+    cfgfile.ensure()
+    assert isinstance(cfg.get_config(None), DefaultCfg)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""
+
+    # Exception when instantiating Config.
+    tmphome.ensure(MyCfg.config_filename)
+    cfgfile.write("def Config(): raise Exception('my_exc')")
+    assert isinstance(cfg.get_config(None), DefaultCfg)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == "** error when getting Config from ~/.mycfg: my_exc **\n"
+
+    # Error during execfile.
+    tmphome.ensure(MyCfg.config_filename)
+    cfgfile.write("invalid_syntax(")
+    assert isinstance(cfg.get_config(None), DefaultCfg)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == "** error when importing ~/.mycfg: unexpected EOF while parsing (.mycfg, line 1) **\n"

--- a/testing/test_configurableclass.py
+++ b/testing/test_configurableclass.py
@@ -36,8 +36,8 @@ def test_config(tmphome, capsys):
 
     # Error during execfile.
     tmphome.ensure(MyCfg.config_filename)
-    cfgfile.write("invalid_syntax(")
+    cfgfile.write("raise Exception('my_execfile_exc')")
     assert isinstance(cfg.get_config(None), DefaultCfg)
     out, err = capsys.readouterr()
     assert out == ""
-    assert err == "** error when importing ~/.mycfg: unexpected EOF while parsing (.mycfg, line 1) **\n"
+    assert err == "** error when importing ~/.mycfg: my_execfile_exc **\n"


### PR DESCRIPTION
- handle missing Config silently
- display errors on stderr

Fixes https://github.com/pdbpp/fancycompleter/issues/12.