### PR TITLE
attr_matches: merge with rlcompleter.attr_matches

### DIFF
--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -288,27 +288,52 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
     def attr_matches(self, text):
         expr, attr = text.rsplit('.', 1)
         if '(' in expr or ')' in expr:  # don't call functions
-            return
+            return []
         try:
-            object = eval(expr, self.namespace)
+            thisobject = eval(expr, self.namespace)
         except Exception:
             return []
+
+        # get the content of the object, except __builtins__
+        words = set(dir(thisobject))
+        words.discard("__builtins__")
+
+        if hasattr(thisobject, '__class__'):
+            words.add('__class__')
+            words.update(rlcompleter.get_class_members(thisobject.__class__))
         names = []
         values = []
         n = len(attr)
-        for word in dir(object):
-            if isinstance(word, unicode) and not PY3K:
-                # this is needed because pyrepl doesn't like unicode
-                # completions: as soon as it finds something which is not str,
-                # it stops.
-                word = word.encode('utf-8')
-            if word[:n] == attr and word != "__builtins__":
-                names.append(word)
-                try:
-                    value = getattr(object, word)
-                except Exception:
-                    value = None
-                values.append(value)
+        if attr == '':
+            noprefix = '_'
+        elif attr == '_':
+            noprefix = '__'
+        else:
+            noprefix = None
+        words = sorted(words)
+        while True:
+            for word in words:
+                if (word[:n] == attr and
+                        not (noprefix and word[:n+1] == noprefix)):
+                    try:
+                        val = getattr(thisobject, word)
+                    except Exception:
+                        val = None  # Include even if attribute not set
+
+                    if not PY3K and isinstance(word, unicode):
+                        # this is needed because pyrepl doesn't like unicode
+                        # completions: as soon as it finds something which is not str,
+                        # it stops.
+                        word = word.encode('utf-8')
+
+                    names.append(word)
+                    values.append(val)
+            if names or not noprefix:
+                break
+            if noprefix == '_':
+                noprefix = '__'
+            else:
+                noprefix = None
 
         if len(names) == 1:
             return ['%s.%s' % (expr, names[0])]  # only option, no coloring.
@@ -316,6 +341,10 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         prefix = commonprefix(names)
         if prefix and prefix != attr:
             return ['%s.%s' % (expr, prefix)]  # autocomplete prefix
+
+        if not self.config.use_colors:
+            return names
+
         return self.color_matches(names, values)
 
     def color_matches(self, names, values):

--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -342,9 +342,6 @@ class Completer(rlcompleter.Completer, ConfigurableClass):
         if prefix and prefix != attr:
             return ['%s.%s' % (expr, prefix)]  # autocomplete prefix
 
-        if not self.config.use_colors:
-            return names
-
         return self.color_matches(names, values)
 
     def color_matches(self, names, values):

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -41,6 +41,9 @@ def test_complete_attribute_prefix():
     assert '__class__' in matches
     assert compl.attr_matches('a.__class') == ['a.__class__']
 
+    compl = Completer({'a': str}, ConfigForTest)
+    assert compl.attr_matches('a._') == ['a.__']
+
 
 def test_complete_attribute_colored():
     compl = Completer({'a': 42}, ColorConfig)

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -1,3 +1,5 @@
+import sys
+
 from fancycompleter import (DefaultConfig, Completer, Color, Installer,
                             commonprefix, LazyVersion)
 
@@ -22,6 +24,20 @@ def test_commonprefix():
 def test_complete_attribute():
     compl = Completer({'a': None}, ConfigForTest)
     assert compl.attr_matches('a.') == ['a.__']
+    matches = compl.attr_matches('a.__')
+    assert 'a.__class__' not in matches
+    assert '__class__' in matches
+    assert compl.attr_matches('a.__class') == ['a.__class__']
+
+
+def test_complete_attribute_prefix():
+    class C(object):
+        attr = 1
+        _attr = 2
+        __attr__attr = 3
+    compl = Completer({'a': C}, ConfigForTest)
+    assert compl.attr_matches('a.') == ['attr', 'mro']
+    assert compl.attr_matches('a._') == ['_C__attr__attr', '_attr']
     matches = compl.attr_matches('a.__')
     assert 'a.__class__' not in matches
     assert '__class__' in matches

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -41,7 +41,7 @@ def test_complete_attribute_prefix():
     assert '__class__' in matches
     assert compl.attr_matches('a.__class') == ['a.__class__']
 
-    compl = Completer({'a': str}, ConfigForTest)
+    compl = Completer({'a': None}, ConfigForTest)
     assert compl.attr_matches('a._') == ['a.__']
 
 

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -126,6 +126,11 @@ def test_complete_invalid_attr():
     assert compl.attr_matches('str.xx') == []
 
 
+def test_complete_function_skipped():
+    compl = Completer({'str': str}, ConfigForTest)
+    assert compl.attr_matches('str.split().') == []
+
+
 def test_unicode_in___dir__():
     class Foo(object):
         def __dir__(self):

--- a/testing/test_fancycompleter.py
+++ b/testing/test_fancycompleter.py
@@ -1,5 +1,3 @@
-import sys
-
 from fancycompleter import (DefaultConfig, Completer, Color, Installer,
                             commonprefix, LazyVersion)
 


### PR DESCRIPTION
This adds better handling of prefixes.

Fixes https://github.com/pdbpp/fancycompleter/issues/16.