### PR TITLE
ci: Travis: fix PATH for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jobs:
     - os: windows
       language: shell
       env:
-        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        - TOXENV=py37-coverage
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - TOXENV=py38-coverage
       before_install:
         - choco install --no-progress python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 after_script:
   - |
     if [[ "${TOXENV%-coverage}" != "$TOXENV" ]]; then
-      bash <(curl -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
+      bash <(curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
     fi
 
 # Only master and releases.  PRs are used otherwise.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: true
+    patch: true
+    changes: true
+comment: false


### PR DESCRIPTION
"choco install python" uses Python 3.8 now.