### PR TITLE
ci: fix codecov upload on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ script:
 after_script:
   - |
     if [[ "${TOXENV%-coverage}" != "$TOXENV" ]]; then
-      bash <(curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
+      curl --version
+      bash <(wget https://codecov.io/bash -O -) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
     fi
 
 # Only master and releases.  PRs are used otherwise.

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ after_script:
   - |
     if [[ "${TOXENV%-coverage}" != "$TOXENV" ]]; then
       curl --version
-      bash <(wget https://codecov.io/bash -O -) -Z -X gcov -X coveragepy -X search -X xcode -X gcovout -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
+      curl -S -L --connect-timeout 5 --retry 6 -s https://codecov.io/bash > codecov.sh
+      bash codecov.sh -Z -X fix -f coverage.xml -n $TOXENV -F "${TRAVIS_OS_NAME}"
     fi
 
 # Only master and releases.  PRs are used otherwise.


### PR DESCRIPTION
`curl` fails on the Windows job, e.g.:

> curl: (23) Failed writing body (0 != 9771)

https://travis-ci.com/pdbpp/fancycompleter/jobs/249344620#L134-L141