### PR TITLE
Update Travis configuration - test on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       env: TOXENV=py36-coverage
     - python: '3.7'
       env: TOXENV=py37-coverage
-    - python: '3.8-dev'
+    - python: '3.8'
       env: TOXENV=py38-coverage
     - python: 'pypy'
       env: TOXENV=pypy-coverage


### PR DESCRIPTION
... not any longer on Python 3.8-dev.