### PR TITLE
Revert "setup.py: use pdbpp/pyrepl@master again"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ jobs:
       env: TOXENV=py37-coverage
     - python: '3.8'
       env: TOXENV=py38-coverage
+    - python: '3.9'
+      env: TOXENV=py39-coverage
+    - python: '3.10'
+      env: TOXENV=py310-coverage
     - python: 'pypy'
       env: TOXENV=pypy-coverage
     - python: 'pypy3'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Topic :: Utilities",
         ],
     install_requires=[
-        "pyrepl @ git+https://github.com/pdbpp/pyrepl@master#egg=pyrepl",
+        "pyrepl>=0.8.2",
         "pyreadline;platform_system=='Windows'",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,38,py,py3}, checkqa
+envlist = py{27,34,35,36,37,38,39,310,py,py3}, checkqa
 
 [testenv]
 deps =


### PR DESCRIPTION
This reverts commit 8ae963eff76b327b7533f39f40d04eb2b99fa3fd.

ref: https://github.com/pdbpp/fancycompleter/pull/3/commits/2d2e7895e832e7e7862dd7f10a4f46fb0dd9f657

JFI: moved to https://github.com/pypy/pyrepl by now.