### PR TITLE
Use pyreadline3 instead of pyreadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ By default, `fancycompleter` tries to use `pyrepl` if it finds it. To
 get colors you need a recent version, \>= 0.8.2.
 
 Starting from version 0.6.1, `fancycompleter` works also on **Windows**,
-relying on [pyreadline](https://pypi.python.org/pypi/pyreadline). At the
-moment of writing, the latest version of `pyreadline` is 2.1, which does
+relying on [pyreadline3](https://pypi.python.org/pypi/pyreadline3). At the
+moment of writing, the latest version of `pyreadline3` is 2.1, which does
 **not** support colored completions; here is the [pull
 request](https://github.com/pyreadline/pyreadline/pull/48) which adds
 support for them. To enable colors, you can install `pyreadline` from

--- a/fancycompleter.py
+++ b/fancycompleter.py
@@ -150,8 +150,8 @@ class DefaultConfig:
     def find_pyreadline(self):
         try:
             import readline
-            import pyreadline  # noqa: F401  # XXX: needed really?
-            from pyreadline.modes import basemode
+            import pyreadline3  # noqa: F401  # XXX: needed really?
+            from pyreadline3.modes import basemode
         except ImportError:
             return None
         if hasattr(basemode, 'stripcolor'):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
         ],
     install_requires=[
         "pyrepl @ git+https://github.com/pdbpp/pyrepl@master#egg=pyrepl",
-        "pyreadline;platform_system=='Windows'",
+        "pyreadline3;platform_system=='Windows'",
     ]
 )


### PR DESCRIPTION
I updated the pyreadline dependency, import, and readme links. I'm not sure how to test that this will pip-install with the correct dependency, though.

There's also some further discussion in the readme about bugs in the current pyreadline (e.g. issue 48); there aren't specific issue links to convert those to, and I don't know which, if any, of those bugs have been fixed in pyreadline3.

This should fix issues #36 and #37 .